### PR TITLE
feat: use stable 'alpine' regctl image tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY ./ ./
 
 RUN CGO_ENABLED=0 go build -o /go/bin/composesync -trimpath -ldflags="-s -w" .
 
-FROM ghcr.io/regclient/regsync:edge-alpine@sha256:2e2977c272d3f796911a915bd3b6bbb9b09541fd1f507a50219aa5753352cf97
+FROM ghcr.io/regclient/regsync:alpine
 
 COPY --from=build /go/bin/composesync /usr/local/bin/
 


### PR DESCRIPTION
We do not need to track the latest builds of regsync in the 'edge:alpine' tag, so base on 'alpine' instead in order to reduce the frequency of updates.